### PR TITLE
add: sdss_explorer dependency check + remove specutils instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ cd sdss_solara
 pip install -e .
 ```
 
-This package currently requires a custom fork of the `specutils` package. For now,
-you must install this separately with the following:
+This package also requires the dashboard application, Explorer, available [here](https://www.github.com/sdss/explorer). You can checkout this package and install it in editable mode as well, or install it with the following:
 ```
-pip install specutils@git+https://github.com/rileythai/specutils-sdss-loaders.git#egg=sdss-v-loaders
+pip install git+https://github.com/sdss/explorer.git@main
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "sdss-tree>4.0.3",
   "sdss-access>3.0.2",
   "solara>0.25.0",
+  "sdss_explorer>=0.0.1",
   "jdaviz>3.8",
 ]
 


### PR DESCRIPTION
- add sdss_explorer dependency check (name to be decided for app)
- changed `specutils` notice since my PR was merged into main and released as [v1.13.0](https://github.com/astropy/specutils/releases/tag/v1.13.0)
- added instructions on how to quickly install sdss_explorer via git checkout with pip