### PR TITLE
Adds routing to main solara app

### DIFF
--- a/sdss_solara/pages/__init__.py
+++ b/sdss_solara/pages/__init__.py
@@ -1,0 +1,17 @@
+
+# import solara
+
+# #from sdss_solara.pages.jdaviz_embed import Page as Embed
+# #from sdss_explorer.pages import Page as Dashboard
+
+
+# @solara.component
+# def Home():
+#     solara.Markdown("SDSS Solara Home")
+
+
+# routes = [
+#     solara.Route(path="/", component=Home, label="Home"),
+#     #solara.Route(path="embed", module=Embed, label="Embed"),
+#     #solara.Route(path="dashboard", component=Dashboard, label="Dashboard"),
+# ]

--- a/sdss_solara/pages/home.py
+++ b/sdss_solara/pages/home.py
@@ -18,5 +18,7 @@ def Home():
 routes = [
     solara.Route(path="/", component=Home, label="Home", layout=Layout),
     solara.Route(path="embed", component=Embed, label="Embed"),
-    solara.Route(path="dashboard", component=Dashboard, label="Dashboard", layout=DashLayout),
+    solara.Route(path="dashboard", layout=DashLayout, children=[
+        solara.Route(path="/", component=Dashboard, label="Dashboard")
+    ]),
 ]

--- a/sdss_solara/pages/home.py
+++ b/sdss_solara/pages/home.py
@@ -1,0 +1,22 @@
+
+import solara
+
+from sdss_solara.pages.jdaviz_embed import Page as Embed
+from sdss_explorer.pages import Page as Dashboard, Layout as DashLayout
+
+@solara.component
+def Layout(children=[]):
+    # there will only be 1 child, which is the Page()
+    return children[0]
+
+
+@solara.component
+def Home():
+    solara.Markdown("SDSS Solara Home")
+
+
+routes = [
+    solara.Route(path="/", component=Home, label="Home", layout=Layout),
+    solara.Route(path="embed", component=Embed, label="Embed"),
+    solara.Route(path="dashboard", component=Dashboard, label="Dashboard", layout=DashLayout),
+]

--- a/sdss_solara/pages/jdaviz_embed.py
+++ b/sdss_solara/pages/jdaviz_embed.py
@@ -250,3 +250,5 @@ def Page():
             Notebook()
 
         Jdaviz()
+
+Page()


### PR DESCRIPTION
this PR closes #2 .  It adds routing for the embedded Jdaviz and Vaex dashboard.  This adds the embed page as a new route under `/embed` and the explorer dashboard under a new `/dashboard` route, both to be available within zora, once the solara application is mounted into valis.   

Marking as draft until we can resolve issues with rendering the desired layout.  