### PR TITLE
Adds new Message component and supports theme changing

### DIFF
--- a/sdss_solara/components/message.py
+++ b/sdss_solara/components/message.py
@@ -1,0 +1,34 @@
+
+import solara
+
+
+@solara.component_vue('message.vue')
+def Message(
+    event_update: solara.Callable[[dict], None] = None):
+    """ iframe post message component """
+    pass
+
+
+def check_theme(theme: str = None):
+    print('check_theme', theme)
+    if theme:
+        solara.lab.theme.dark = theme == 'dark'
+    else:
+        solara.lab.theme.dark = solara.lab.theme.dark_effective
+
+
+
+def event_handler(data: dict):
+    """ postMessage event handler """
+
+    print('event data', data)
+    event_type = data.get('type')
+    if event_type == 'themeChange':
+        check_theme(data.get('theme'))
+
+
+def set_initial_theme():
+    router = solara.use_router()
+    params = dict(i.split('=') for i in router.search.split('&')) if router.search else {}
+    theme = params.get('theme')
+    check_theme(theme)

--- a/sdss_solara/components/message.vue
+++ b/sdss_solara/components/message.vue
@@ -1,0 +1,32 @@
+<template>
+    <p style="display: none;"></p>
+</template>
+
+<script>
+export default {
+    props: {
+    },
+    data() {
+        return {
+            lastMessageType: '',
+            postData: {}
+        }
+    },
+    mounted() {
+        window.addEventListener('message', this.handleMessage)
+    },
+    beforeUnmount() {
+        window.removeEventListener('message', this.handleMessage)
+    },
+    methods: {
+        handleMessage(event) {
+            // event handler for postMessage
+            if (event.data && event.data.type) {
+                this.lastMessageType = event.data.type
+                this.postData = event.data
+                this.update(this.postData)
+            }
+        }
+    }
+}
+</script>

--- a/sdss_solara/pages/home.py
+++ b/sdss_solara/pages/home.py
@@ -3,6 +3,7 @@ import solara
 
 from sdss_solara.pages.jdaviz_embed import Page as Embed
 from sdss_explorer.pages import Page as Dashboard, Layout as DashLayout
+from sdss_solara.components.message import Message, event_handler, set_initial_theme
 
 @solara.component
 def Layout(children=[]):
@@ -13,12 +14,22 @@ def Layout(children=[]):
 @solara.component
 def Home():
     solara.Markdown("SDSS Solara Home")
+    Message(event_update=event_handler)
+
+
+@solara.component
+def NewDash():
+    """ hack to insert the iframe message event handler into the dashboard """
+    set_initial_theme()
+    with solara.Column():
+        Message(event_update=event_handler)
+        Dashboard()
 
 
 routes = [
     solara.Route(path="/", component=Home, label="Home", layout=Layout),
     solara.Route(path="embed", component=Embed, label="Embed"),
     solara.Route(path="dashboard", layout=DashLayout, children=[
-        solara.Route(path="/", component=Dashboard, label="Dashboard")
+        solara.Route(path="/", component=NewDash, label="Dashboard")
     ]),
 ]

--- a/sdss_solara/pages/jdaviz_embed.py
+++ b/sdss_solara/pages/jdaviz_embed.py
@@ -7,6 +7,7 @@ import requests
 import solara
 
 from sdss_access import Access
+from sdss_solara.components.message import Message, event_handler, set_initial_theme
 
 
 def get_url():
@@ -241,8 +242,12 @@ def Page():
 
     print(params.value)
 
+    # set initial theme
+    set_initial_theme()
+
     with solara.Column():
         solara.Title("Spectral Display")
+        Message(event_update=event_handler)
 
         with solara.Columns([1, 0, 0], style='margin: 0 5px'):
             DataSelect()


### PR DESCRIPTION
This PR adds a new `Message` component to as a handler for iframe postMessage events.  It adds initial support for changing the solara theme based on a received postMessage event.  Updates the jdaviz embed page and a hack wrapper for the DataView dashboard to listen for message events.  
