### PR TITLE
Smart rescaling of noisy spectral data

### DIFF
--- a/sdss_solara/pages/jdaviz_embed.py
+++ b/sdss_solara/pages/jdaviz_embed.py
@@ -3,6 +3,7 @@ import pathlib
 
 import dotenv
 import nbformat as nbf
+import numpy as np
 import requests
 import solara
 
@@ -190,6 +191,20 @@ def Notebook():
             solara.Button(label='Download Jupyter notebook', color='primary')
 
 
+def smart_resize(specviz):
+    """ placeholder function to resize init data """
+    # get spectra
+    ss = specviz.get_spectra()
+    key = next(iter(ss))
+    spec = ss[key]
+
+    # adjust plot y limits to 99th percentile
+    scale = 1.5
+    plot_options = specviz.plugins['Plot Options']
+    plot_options.y_min.value = np.percentile(spec.flux, 1).value * scale
+    plot_options.y_max.value = np.percentile(spec.flux, 99).value * scale
+
+
 @solara.component
 def Jdaviz():
     """ component for displaying Jdaviz """
@@ -240,6 +255,7 @@ def Jdaviz():
         if filemap.value:
             val = filemap.value[list(filemap.value.keys())[0]]
             spec.value.load_data(val)
+            smart_resize(spec.value)
 
         display(spec.value.app)
 


### PR DESCRIPTION
This PR closes #6 and adds a temporary workaround for re-scaling the y-axis of noisy spectral data.  It computes the 1-99th percentile of the spectral data, then multiplies by scaling factor of 1.5, to provide a buffer.   This should work until a fix can get implemented in upstream Jdaviz