### PR TITLE
Updates jdaviz to support mwmVisit files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ dependencies = [
   "sdss-tree>4.0.3",
   "sdss-access>3.0.2",
   "markdown",
-  "solara[all]>1.39.0",
-  "solara-ui[all]>1.39.0",
+  "solara[all]>1.41.0",
+  "solara-ui[all]>1.41.0",
   "sdss_explorer@git+https://github.com/sdss/explorer.git#egg=main",
   "photutils>1.13",
-  "jdaviz>3.10",
+  "jdaviz>4.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "solara-ui[all]>1.41.0",
   "sdss_explorer@git+https://github.com/sdss/explorer.git#egg=main",
   "photutils>1.13",
-  "jdaviz>4.0",
+  "jdaviz>4.1",
 ]
 
 [project.optional-dependencies]

--- a/sdss_solara/components/message.py
+++ b/sdss_solara/components/message.py
@@ -29,6 +29,6 @@ def event_handler(data: dict):
 
 def set_initial_theme():
     router = solara.use_router()
-    params = dict(i.split('=') for i in router.search.split('&')) if router.search else {}
+    params = dict(i.split('=', 1) for i in router.search.split('&')) if router.search else {}
     theme = params.get('theme')
     check_theme(theme)

--- a/sdss_solara/pages/jdaviz_embed.py
+++ b/sdss_solara/pages/jdaviz_embed.py
@@ -307,7 +307,7 @@ def Jdaviz():
 def Page():
     """ main page component """
     router = solara.use_router()
-    params.value = dict(i.split('=') for i in router.search.split('&')) if router.search else {}
+    params.value = dict(i.split('=', 1) for i in router.search.split('&')) if router.search else {}
 
     print(params.value)
 

--- a/sdss_solara/pages/jdaviz_embed.py
+++ b/sdss_solara/pages/jdaviz_embed.py
@@ -52,7 +52,10 @@ def get_specformat(filepath: str) -> str:
         return 'SDSS-III/IV spec'
     elif fnmatch.fnmatch(filepath, '*astra/*/mwmStar*'):
         # loads all extensions
-        return 'SDSS-V mwm multi'
+        return 'SDSS-V mwm'
+    elif fnmatch.fnmatch(filepath, '*astra/*/mwmVisit*'):
+        # loads all extensions
+        return 'SDSS-V mwm'
     else:
         return None
 
@@ -133,8 +136,9 @@ def DataLoader():
         for f in selected.value:
             label = f'{pathlib.Path(f).stem}'
             speclabels = set(i.split(' ', 1)[0] for i in spec.value.app.data_collection.labels)
+            lal = True if 'mwmVisit' in label or 'apVisit' in label else False
             if label not in speclabels:
-                spec.value.load_data(filemap.value[f], format=get_specformat(filemap.value[f]))
+                spec.value.load_data(filemap.value[f], format=get_specformat(filemap.value[f]), load_as_list=lal)
 
     solara.Button('Load Data', color='primary', on_click=load)
 
@@ -292,7 +296,8 @@ def Jdaviz():
         if filemap.value:
             label = list(filemap.value.keys())[0]
             val = filemap.value[label]
-            spec.value.load_data(val, format=get_specformat(val))
+            lal = True if 'mwmVisit' in label or 'apVisit' in label else False
+            spec.value.load_data(val, format=get_specformat(val), load_as_list=lal)
             smart_resize(spec.value)
 
         display(spec.value.app)


### PR DESCRIPTION
This PR updates the Jdaviz embed to support the display of the mwmVisit files, all extensions.  It needs specutils 1.19 and the latest jdaviz.  We need to wait until https://github.com/spacetelescope/jdaviz/pull/3229 is included in the next release, tentatively planned for 4.1 release.  Closes #9 