### PR TITLE
Some restructure, cleanup and fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, macos-14]
         python-version: ["3.12", "3.13", "3.14"]
+        vaex-mode: [plain, fallback-wheels]
 
     runs-on: ${{ matrix.os }}
 
@@ -47,6 +48,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install vaex (plain)
+        if: matrix.vaex-mode == 'plain'
+        run: python -m pip install --force-reinstall vaex
+
+      - name: Install vaex (fallback wheels)
+        if: matrix.vaex-mode == 'fallback-wheels'
+        env:
+          PIP_FIND_LINKS: https://github.com/ddelange/vaex/releases/expanded_assets/core-v4.17.1.post4
+        run: python -m pip install --force-reinstall vaex
 
       - name: Install package from pyproject.toml
         run: python -m pip install .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,52 +26,15 @@ jobs:
       - name: Install package from pyproject.toml (no dependencies)
         run: python -m pip install --no-deps .
 
-      - name: Verify package import
-        run: python -c "import sdss_solara; print(sdss_solara.__name__)"
-
-  install-matrix:
+  build-matrix:
     continue-on-error: true
-    timeout-minutes: 10
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-14]
-        python-version: ["3.12"]
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
-
-      - name: Install package from pyproject.toml
-        run: python -m pip install .
-
-      - name: Show resolved dependency versions
-        if: always()
-        run: python -m pip freeze | grep -E '^(sdss_explorer|vaex)'
-
-      - name: Verify package import
-        run: python -c "import sdss_solara; print(sdss_solara.__name__)"
-
-  install-matrix-experimental:
-    continue-on-error: true
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, macos-14]
         python-version: ["3.13", "3.14"]
 
-    runs-on: ${{ matrix.os }}
-
     steps:
       - uses: actions/checkout@v4
 
@@ -80,15 +43,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Upgrade pip
-        run: python -m pip install --upgrade pip
+      - name: Install packaging tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
 
-      - name: Install package from pyproject.toml
-        run: python -m pip install .
+      - name: Build package
+        run: python -m build
 
-      - name: Show resolved dependency versions
-        if: always()
-        run: python -m pip freeze | grep -E '^(sdss_explorer|vaex)'
-
-      - name: Verify package import
-        run: python -c "import sdss_solara; print(sdss_solara.__name__)"
+      - name: Install package from pyproject.toml (no dependencies)
+        run: python -m pip install --no-deps .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,30 +3,17 @@ name: Build Package
 on: [push, pull_request]
 
 jobs:
-  build:
-    continue-on-error: ${{ matrix.allow_failure }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
-        include:
-          - python-version: "3.12"
-            allow_failure: false
-          - python-version: "3.13"
-            allow_failure: true
-          - python-version: "3.14"
-            allow_failure: true
-
+  build-package:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Install packaging tools
         run: |
@@ -35,6 +22,31 @@ jobs:
 
       - name: Build package
         run: python -m build
+
+      - name: Install package from pyproject.toml (no dependencies)
+        run: python -m pip install --no-deps .
+
+      - name: Verify package import
+        run: python -c "import sdss_solara; print(sdss_solara.__name__)"
+
+  install-matrix:
+    continue-on-error: true
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-14]
+        python-version: ["3.13", "3.14"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install package from pyproject.toml
         run: python -m pip install .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, macos-14]
-        python-version: ["3.12", "3.13", "3.14"]
-        vaex-mode: [plain, fallback-wheels]
+        python-version: ["3.12"]
 
     runs-on: ${{ matrix.os }}
 
@@ -52,18 +51,44 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
 
-      - name: Install vaex (plain)
-        if: matrix.vaex-mode == 'plain'
-        run: python -m pip install --force-reinstall vaex
+      - name: Install package from pyproject.toml
+        run: python -m pip install .
 
-      - name: Install vaex (fallback wheels)
-        if: matrix.vaex-mode == 'fallback-wheels'
-        env:
-          PIP_FIND_LINKS: https://github.com/ddelange/vaex/releases/expanded_assets/core-v4.17.1.post4
-        run: python -m pip install --force-reinstall vaex
+      - name: Show resolved dependency versions
+        if: always()
+        run: python -m pip freeze | grep -E '^(sdss_explorer|vaex)'
+
+      - name: Verify package import
+        run: python -c "import sdss_solara; print(sdss_solara.__name__)"
+
+  install-matrix-experimental:
+    continue-on-error: true
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-14]
+        python-version: ["3.13", "3.14"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: Install package from pyproject.toml
         run: python -m pip install .
+
+      - name: Show resolved dependency versions
+        if: always()
+        run: python -m pip freeze | grep -E '^(sdss_explorer|vaex)'
 
       - name: Verify package import
         run: python -c "import sdss_solara; print(sdss_solara.__name__)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, macos-14]
-        python-version: ["3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build Package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    continue-on-error: ${{ matrix.allow_failure }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+        include:
+          - python-version: "3.12"
+            allow_failure: false
+          - python-version: "3.13"
+            allow_failure: true
+          - python-version: "3.14"
+            allow_failure: true
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build package
+        run: python -m build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install build dependencies
+      - name: Install packaging tools
         run: |
           python -m pip install --upgrade pip
           python -m pip install build
 
       - name: Build package
         run: python -m build
+
+      - name: Install package from pyproject.toml
+        run: python -m pip install .
+
+      - name: Verify package import
+        run: python -c "import sdss_solara; print(sdss_solara.__name__)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "solara-ui[all]>1.41.0",
   "sdss_explorer@git+https://github.com/sdss/explorer.git#egg=main",
   "photutils>1.13",
-  "jdaviz>4.1,4.3",
+  "jdaviz>4.1,<4.3",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "solara-ui[all]>1.41.0",
   "sdss_explorer@git+https://github.com/sdss/explorer.git#egg=main",
   "photutils>1.13",
-  "jdaviz>4.1",
+  "jdaviz>4.1,4.3",
 ]
 
 [project.optional-dependencies]

--- a/sdss_solara/components/common.py
+++ b/sdss_solara/components/common.py
@@ -1,0 +1,45 @@
+import os
+
+import ipygoldenlayout
+import ipysplitpanes
+import ipyvue
+import jdaviz
+from jdaviz.app import custom_components
+
+
+def create_shared_widgets():
+    """Create shared widgets
+
+    Necessary fix to display jdaviz with solara properly
+    """
+    ipysplitpanes.SplitPanes()
+    ipygoldenlayout.GoldenLayout()
+    for name, path in custom_components.items():
+        ipyvue.register_component_from_file(
+            None, name, os.path.join(os.path.dirname(jdaviz.__file__), path)
+        )
+
+    ipyvue.register_component_from_file(
+        "g-viewer-tab", "container.vue", jdaviz.__file__
+    )
+
+
+# custom css to fix jdaviz height display when embedding
+css = """
+    main.v-content.solara-content-main {
+        padding: 0px !important;
+    }
+
+    .widget-output {
+        margin: 0;
+    }
+
+    .jdaviz {
+        height: 100vh !important;
+    }
+
+    .v-content.jdaviz__content--not-in-notebook {
+        height: 100vh !important;
+        max-height: 100vh
+    }
+    """

--- a/sdss_solara/pages/jdaviz_embed.py
+++ b/sdss_solara/pages/jdaviz_embed.py
@@ -1,25 +1,57 @@
 import fnmatch
 import os
 import pathlib
+import urllib
 
 import dotenv
 import nbformat as nbf
 import numpy as np
 import requests
 import solara
-
+from jdaviz import Specviz
+from jdaviz.app import Application
 from sdss_access import Access
+from specutils import Spectrum, SpectrumList
+
+from sdss_solara.components.common import create_shared_widgets, css
 from sdss_solara.components.message import Message, event_handler, set_initial_theme
 
 
+def local_check():
+    """Check localality"""
+    local = False
+    if solara.lab.headers.value:
+        hosts = solara.lab.headers.value.get("host")
+        hosts = hosts[0] if hosts else ""
+        local = "localhost" in hosts
+
+    return local and params.value.get("test")
+
+
+def load_test_data(release: str):
+    """Load test data from the SAS"""
+
+    if "IPL" in release.upper() and "-" not in release:
+        release = release.upper().replace("IPL", "IPL-")
+    sas = os.getenv("SAS_BASE_DIR")
+    files = (pathlib.Path(sas) / release.lower()).rglob("*.fits")
+    return ",".join((i.as_posix() for i in files))
+
+
 def get_url():
-    """ get the valis api url """
+    """get the valis api url"""
     url = os.getenv("VALIS_API_URL")
     if url:
         return url
 
-    env = os.getenv("VALIS_ENV") or os.getenv("SOLARA_ENV") or ''
-    name = '.env.dev' if env.startswith("dev") else '.env.test' if env.startswith('test') else '.env.prod'
+    env = os.getenv("VALIS_ENV") or os.getenv("SOLARA_ENV") or ""
+    name = (
+        ".env.dev"
+        if env.startswith("dev")
+        else ".env.test"
+        if env.startswith("test")
+        else ".env.prod"
+    )
     dotenv.load_dotenv(dotenv.find_dotenv(name))
     return os.getenv("VALIS_API_URL")
 
@@ -28,58 +60,67 @@ api_url = get_url()
 
 
 def get_config():
-    """ create custom jdaviz configuration """
+    """create custom jdaviz configuration"""
     from jdaviz.core.config import get_configuration
 
     # get the default specviz config
-    config = get_configuration('specviz')
+    config = get_configuration("specviz")
 
     # set custom settings for embedding
-    config['settings']['viewer_spec'] = config['settings'].get('configuration', 'default')
-    config['settings']['server_is_remote'] = True
-    config['toolbar'].remove('g-data-tools') if config['toolbar'].count('g-data-tools') else None
+    config["settings"]["viewer_spec"] = config["settings"].get(
+        "configuration", "default"
+    )
+    config["settings"]["server_is_remote"] = True
+    config["settings"]["remote_enable_importers"] = True
+    config["toolbar"].remove("g-data-tools") if config["toolbar"].count(
+        "g-data-tools"
+    ) else None
 
     return config
 
 
 def get_specformat(filepath: str) -> str:
-    """ Get the Spectrum1D format based on the filepath """
-    if fnmatch.fnmatch(filepath, '*apogee/*/dr17/visit*'):
-        return 'APOGEE apVisit'
-    elif fnmatch.fnmatch(filepath, '*apogee/*/dr17/stars*'):
-        return 'APOGEE apStar'
-    elif fnmatch.fnmatch(filepath, '*dr17/eboss/spectro*'):
-        return 'SDSS-III/IV spec'
-    elif fnmatch.fnmatch(filepath, '*dr17/sdss/spectro*'):
-        return 'SDSS-III/IV spec'
-    elif fnmatch.fnmatch(filepath, '*boss/redux/v6*'):
-        return 'SDSS-V spec'
-    elif fnmatch.fnmatch(filepath, '*astra/*/mwmStar*'):
+    """Get the Spectrum1D format based on the filepath"""
+    if fnmatch.fnmatch(filepath, "*apogee/*/dr17/visit*"):
+        return "APOGEE apVisit"
+    elif fnmatch.fnmatch(filepath, "*apogee/*/dr17/stars*"):
+        return "APOGEE apStar"
+    elif fnmatch.fnmatch(filepath, "*apogee/redux/1.*/stars*"):
+        return "SDSS-V apStar"
+    elif fnmatch.fnmatch(filepath, "*apogee/redux/1.*/visit*"):
+        return "SDSS-V apVisit"
+    elif fnmatch.fnmatch(filepath, "*dr17/eboss/spectro*"):
+        return "SDSS-III/IV spec"
+    elif fnmatch.fnmatch(filepath, "*dr17/sdss/spectro*"):
+        return "SDSS-III/IV spec"
+    elif fnmatch.fnmatch(filepath, "*boss/redux/v6*"):
+        return "SDSS-V spec"
+    elif fnmatch.fnmatch(filepath, "*astra/*/mwmStar*"):
         # loads all extensions
-        return 'SDSS-V mwm'
-    elif fnmatch.fnmatch(filepath, '*astra/*/mwmVisit*'):
+        return "SDSS-V mwm"
+    elif fnmatch.fnmatch(filepath, "*astra/*/mwmVisit*"):
         # loads all extensions
-        return 'SDSS-V mwm'
-    elif fnmatch.fnmatch(filepath, '*dr17/manga/*LOGCUBE*'):
+        return "SDSS-V mwm"
+    elif fnmatch.fnmatch(filepath, "*dr17/manga/*LOGCUBE*"):
         # loads all extensions
-        return 'MaNGA cube'
-    elif fnmatch.fnmatch(filepath, '*dr17/manga/*LOGRSS*'):
+        return "MaNGA cube"
+    elif fnmatch.fnmatch(filepath, "*dr17/manga/*LOGRSS*"):
         # loads all extensions
-        return 'MaNGA rss'
+        return "MaNGA rss"
     else:
         return None
 
 
 def sort_filemap(data: dict) -> dict:
-    """ Sort the filemap by file preference """
-    prefs = ['mwmStar', 'spec', 'apStar']
+    """Sort the filemap by file preference"""
+    prefs = ["mwmStar", "spec", "apStar"]
     prior = dict(zip(prefs, range(len(prefs))))
 
     def get_prior(x):
         for i in prefs:
             if x.startswith(i):
                 return prior[i]
-        return float('inf')
+        return float("inf")
 
     skeys = sorted(data.keys(), key=get_prior)
     return {key: data[key] for key in skeys}
@@ -92,31 +133,71 @@ filemap = solara.reactive({})
 params = solara.reactive({})
 
 
+def get_spectrum(label: str):
+    """Get the specutils Spectrum object"""
+    lal = (
+        True
+        if label.startswith(("mwmVisit", "mwmStar"))
+        or "apVisit" in label
+        or "apStar" in label
+        else False
+    )
+    spec_format = get_specformat(filemap.value[label])
+    if lal:
+        return SpectrumList.read(filemap.value[label], format=spec_format)
+    return Spectrum.read(filemap.value[label], format=spec_format)
+
+
+def make_label(filepath):
+    """Make a data label that accounts for spec coadds"""
+    stem = pathlib.Path(filepath).stem
+    parts = stem.split("-", 1)
+    if "spectra/daily" in filepath:
+        parts.insert(1, "daily")
+        return "-".join(parts)
+    elif "spectra/epoch" in filepath:
+        parts.insert(1, "epoch")
+        return "-".join(parts)
+    elif "spectra/lite" in filepath:
+        parts.insert(1, "lite")
+        return "-".join(parts)
+    elif "spectra/full" in filepath:
+        parts.insert(1, "full")
+        return "-".join(parts)
+    else:
+        return stem
+
+
 @solara.component
 def DataSelect():
-    """ component for a dropdown select menu """
+    """component for a dropdown select menu"""
     all_files = solara.use_reactive([])
 
-    sdssid = params.value.get('sdssid', '')
-    release = params.value.get('release', 'IPL3')
-    qp_files = params.value.get('files', '')
+    sdssid = params.value.get("sdssid", "")
+    release = params.value.get("release", "IPL3")
+    qp_files = params.value.get("files", "")
+    # allowing test data
+    if local_check():
+        sdssid = 123456
+        qp_files = load_test_data(release)
 
     def make_request():
-        """ make a valis request to get the spectral data files """
+        """make a valis request to get the spectral data files"""
         if not sdssid:
             return []
 
-        resp = requests.get(api_url + f'/target/pipelines/{sdssid}',
-                            json={'release': release})
+        resp = requests.get(
+            api_url + f"/target/pipelines/{sdssid}", json={"release": release}
+        )
         if not resp.ok:
             return []
 
-        vals = {pathlib.Path(i).name: i for i in resp.json()['files'].values()}
-        filemap.value = sort_filemap(vals) if not set(vals) == {''} else {}
+        vals = {make_label(i): i for i in resp.json()["files"].values()}
+        filemap.value = sort_filemap(vals) if not set(vals) == {""} else {}
         return list(filemap.value.keys())
 
     def get_files():
-        """ get the spectral data files """
+        """get the spectral data files"""
         if filemap.value:
             all_files.value = list(filemap.value.keys())
             selected.value = [all_files.value[0]] if all_files.value else []
@@ -124,12 +205,14 @@ def DataSelect():
 
         if sdssid and not qp_files:
             res = make_request()
-            print('finished req', res)
+            print("finished req", res)
             all_files.value = res or []
             selected.value = [all_files.value[0]] if all_files.value else []
         elif sdssid and qp_files:
-            print('getting files', sdssid, qp_files)
-            filemap.value = sort_filemap({pathlib.Path(i).name: i for i in qp_files.split(',')})
+            print("getting files", sdssid, qp_files)
+            filemap.value = sort_filemap(
+                {make_label(i): i for i in qp_files.split(",")}
+            )
             all_files.value = list(filemap.value.keys())
             selected.value = [all_files.value[0]] if all_files.value else []
 
@@ -139,29 +222,51 @@ def DataSelect():
     solara.SelectMultiple("Select Data Files", selected, all_files.value, dense=True)
 
 
+def load_data(app: Application, filename: str):
+    """Load the data into Jdaviz"""
+    label = make_label(filename)
+    lal = (
+        True
+        if label.startswith(("mwmVisit", "mwmStar"))
+        or "apVisit" in label
+        or "apStar" in label
+        else False
+    )
+
+    # 4.2.3
+    app.load_data(
+        filename, format=get_specformat(filename), load_as_list=lal, data_label=label
+    )
+    # obj = get_spectrum(label)
+    # app.load_data(obj, format=get_specformat(filename), load_as_list=lal, data_label=label, sources='*')
+
+
 @solara.component
 def DataLoader():
-    """ component for data loading button """
+    """component for data loading button"""
+
     def load():
         for f in selected.value:
-            label = f'{pathlib.Path(f).stem}'
-            speclabels = set(i.split(' ', 1)[0] for i in spec.value.app.data_collection.labels)
-            lal = True if label.startswith(('mwmVisit', 'mwmStar')) or 'apVisit' in label else False
+            label = make_label(filemap.value[f])
+            speclabels = set(
+                i.split(" ", 1)[0] for i in spec.value.app.data_collection.labels
+            )
             if label not in speclabels:
-                spec.value.load_data(filemap.value[f], format=get_specformat(filemap.value[f]), load_as_list=lal)
+                load_data(spec.value, filemap.value[f])
 
-    solara.Button('Load Data', color='primary', on_click=load)
+    solara.Button("Load Data", color="primary", on_click=load)
 
 
-def get_urls(files, release):
+def get_urls(files: list, release: str):
+    """Get the access urls for the files"""
     access = Access(release=release)
     access.remote()
-    sasdir = 'sas' if access.access_mode == 'curl' else ''
-    return [access.url('', full=f, sasdir=sasdir) for f in files if f]
+    sasdir = "sas" if access.access_mode == "curl" else ""
+    return [access.url("", full=f, sasdir=sasdir) for f in files if f]
 
 
-def get_nb(files, release, sdssid):
-
+def get_nb(files: list, release: str, sdssid: str):
+    """Create a dynamic notebook"""
     # get the urls to render
     urls = get_urls(files, release)
 
@@ -217,122 +322,105 @@ spec.show()
     """
 
     # add the cells
-    nb['cells'] = [nbf.v4.new_markdown_cell(text),
-                   nbf.v4.new_code_cell(code),
-                   nbf.v4.new_code_cell(code2),
-                   nbf.v4.new_code_cell(code3),
-                   ]
+    nb["cells"] = [
+        nbf.v4.new_markdown_cell(text),
+        nbf.v4.new_code_cell(code),
+        nbf.v4.new_code_cell(code2),
+        nbf.v4.new_code_cell(code3),
+    ]
 
     return nbf.writes(nb)
 
 
 @solara.component
 def Notebook():
-    """ component for download a Jupyter notebook """
+    """component for download a Jupyter notebook"""
     files = list(filemap.value.values())
-    sdssid = params.value.get('sdssid')
-    nbobj = get_nb(files, params.value.get('release'), sdssid)
-    with solara.FileDownload(nbobj, f"sdss_jdaviz_notebook_{sdssid}.ipynb", mime_type="application/x-ipynb+json"):
+    sdssid = params.value.get("sdssid")
+    nbobj = get_nb(files, params.value.get("release"), sdssid)
+    with solara.FileDownload(
+        nbobj,
+        f"sdss_jdaviz_notebook_{sdssid}.ipynb",
+        mime_type="application/x-ipynb+json",
+    ):
         with solara.Tooltip("Download a Jdaviz Jupyter notebook for these data"):
-            solara.Button(label='Download Jupyter notebook', color='primary')
+            solara.Button(label="Download Jupyter notebook", color="primary")
 
 
 def smart_resize(specviz):
-    """ placeholder function to resize init data """
+    """placeholder function to resize init data"""
     # get spectra
     ss = specviz.get_spectra()
     key = next(iter(ss))
     spec = ss[key]
 
     # skip smart resize if the outlier threshold is low
-    threshold = np.abs(np.nanmax(spec.flux)/np.nanmedian(spec.flux)).value
+    threshold = np.abs(np.nanmax(spec.flux) / np.nanmedian(spec.flux)).value
     if threshold < 100:
         return
 
     # adjust plot y limits to 99th percentile
     scale = 1.5
-    plot_options = specviz.plugins['Plot Options']
+    plot_options = specviz.plugins["Plot Options"]
     plot_options.y_min.value = np.nanpercentile(spec.flux, 1).value * scale
     plot_options.y_max.value = np.nanpercentile(spec.flux, 99).value * scale
 
 
+def load_app():
+    """Load the application and data"""
+    config = get_config()
+    app = Application(configuration=config)
+    style_path = pathlib.Path(__file__).parent / "custom_jdaviz.vue"
+    app._add_style(str(style_path))
+    spec.value = Specviz(app)
+    error = None
+    if filemap.value:
+        label = list(filemap.value.keys())[0]
+        load_data(spec.value, filemap.value[label])
+        smart_resize(spec.value)
+
+    return app, error
+
+
 @solara.component
 def Jdaviz():
-    """ component for displaying Jdaviz """
-    from IPython.display import display
-    import jdaviz
-    from jdaviz import Specviz, Application
-    import ipysplitpanes
-    import ipygoldenlayout
-    import ipyvue
-    import os
-    from jdaviz.app import custom_components
+    """component for displaying Jdaviz"""
+    # prevents infinite recursion
+    solara.use_memo(create_shared_widgets, [])
+    app, error = solara.use_memo(load_app, [])
 
-    ipysplitpanes.SplitPanes()
-    ipygoldenlayout.GoldenLayout()
-    for name, path in custom_components.items():
-        ipyvue.register_component_from_file(None, name, os.path.join(os.path.dirname(jdaviz.__file__), path))
-
-    ipyvue.register_component_from_file('g-viewer-tab', "container.vue", jdaviz.__file__)
-
-    css = """
-    main.v-content.solara-content-main {
-        padding: 0px !important;
-    }
-
-    .widget-output {
-        margin: 0;
-    }
-
-    .jdaviz {
-        height: 100vh !important;
-    }
-
-    .v-content.jdaviz__content--not-in-notebook {
-        height: 100vh !important;
-        max-height: 100vh
-    }
-    """
-
-    solara.Style(css)
-    with solara.Column():
-
-        config = get_config()
-        app = Application(configuration=config)
-        style_path = pathlib.Path(__file__).parent / 'custom_jdaviz.vue'
-        app._add_style(str(style_path))
-        spec.value = Specviz(app)
-
-        if filemap.value:
-            label = list(filemap.value.keys())[0]
-            val = filemap.value[label]
-            lal = True if label.startswith(('mwmVisit', 'mwmStar')) or 'apVisit' in label else False
-            spec.value.load_data(val, format=get_specformat(val), load_as_list=lal)
-            smart_resize(spec.value)
-
-        display(spec.value.app)
+    children = []
+    if error:
+        children.append(solara.Alert(error, color="danger", dense=True))
+    else:
+        children.append(app)
+    return solara.Column(children=children).meta(ref="jdaviz")
 
 
 @solara.component
 def Page():
-    """ main page component """
+    """main page component"""
+    # extract query params
     router = solara.use_router()
-    params.value = dict(i.split('=', 1) for i in router.search.split('&')) if router.search else {}
+    pp = urllib.parse.parse_qs(router.search)
+    params.value = {k: v[0] if len(v) == 1 else v for k, v in pp.items()}
 
     print(params.value)
 
     # set initial theme
     set_initial_theme()
 
+    solara.Style(css)
     with solara.Column():
         solara.Title("Spectral Display")
         Message(event_update=event_handler)
 
-        with solara.Columns([1, 0, 0], style='margin: 0 5px'):
+        with solara.Columns([1, 0, 0], style="margin: 0 5px"):
             DataSelect()
             DataLoader()
             Notebook()
 
         Jdaviz()
+
 
 Page()

--- a/sdss_solara/tests/test_loads.py
+++ b/sdss_solara/tests/test_loads.py
@@ -1,0 +1,70 @@
+import pytest
+
+from sdss_solara.pages.jdaviz_embed import get_specformat
+
+
+TEST_FILES = [
+    (
+        "spectro/boss/redux/v6_2_1/spectra/epoch/lite/112XXX/112360/60287/spec-112360-60287-27021603143302004.fits",
+        "SDSS-V spec",
+    ),
+    (
+        "spectro/boss/redux/v6_2_1/spectra/epoch/lite/100XXX/100129/60624/spec-100129-60624-63050394785558224.fits",
+        "SDSS-V spec",
+    ),
+    (
+        "spectro/boss/redux/v6_2_1/spectra/allepoch/lite/allepoch/allepoch_apo/59373/spec-allepoch_apo-59373-4351657527.fits",
+        "SDSS-V spec",
+    ),
+    (
+        "dr17/sdss/spectro/redux/26/spectra/lite/2895/spec-2895-54567-0346.fits",
+        "SDSS-III/IV spec",
+    ),
+    (
+        "dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGCUBE.fits.gz",
+        "MaNGA cube",
+    ),
+    (
+        "dr17/manga/spectro/redux/v3_1_1/8485/stack/manga-8485-1901-LOGRSS.fits.gz",
+        "MaNGA rss",
+    ),
+    (
+        "apogee/spectro/redux/dr17/stars/apo25m/293+62_btx/apStar-dr17-2M12305537+0034282.fits",
+        "APOGEE apStar",
+    ),
+    (
+        "apogee/spectro/redux/dr17/visit/apo25m/100129/16442/60595/apVisit-1.5-apo25m-16442-60595-211.fits",
+        "APOGEE apVisit",
+    ),
+    (
+        "dr17/eboss/spectro/redux/v5_13_2/spectra/lite/10235/spec-10235-58127-0006.fits",
+        "SDSS-III/IV spec",
+    ),
+    (
+        "spectro/boss/redux/v6_2_1/spectra/epoch/lite/112XXX/112360/60287/spec-112360-60287-27021603143302004.fits",
+        "SDSS-V spec",
+    ),
+    (
+        "spectro/boss/redux/v6_2_1/spectra/allepoch/lite/allepoch/allepoch_apo/59373/spec-allepoch_apo-59373-4351657527.fits",
+        "SDSS-V spec",
+    ),
+    (
+        "spectro/boss/redux/v6_2_1/spectra/daily/lite/100XXX/100129/59805/spec-100129-59805-27021597855027663.fits",
+        "SDSS-V spec",
+    ),
+    (
+        "spectro/apogee/redux/1.5/stars/apo25m/11/11410/apStar-1.5-apo25m-2M00490869+6205128.fits",
+        "SDSS-V apStar",
+    ),
+    (
+        "spectro/apogee/redux/1.5/visit/apo25m/100129/16442/60595/apVisit-1.5-apo25m-16442-60595-211.fits",
+        "SDSS-V apVisit",
+    ),
+    ("spectro/astra/spectra/star/92/73/mwmStar-0.8.0-54459273.fits", "SDSS-V mwm"),
+    ("spectro/astra/spectra/visit/92/73/mwmVisit-0.8.0-54459273.fits", "SDSS-V mwm"),
+]
+
+
+@pytest.mark.parametrize("filepath, expected", TEST_FILES)
+def test_get_specformat(filepath, expected):
+    assert get_specformat(filepath) == expected

--- a/sdss_solara/tests/test_loads.py
+++ b/sdss_solara/tests/test_loads.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sdss_solara.pages.jdaviz_embed import get_specformat
+from sdss_solara.pages.jdaviz_embed import get_specformat, make_label, sort_filemap
 
 
 TEST_FILES = [
@@ -67,4 +67,62 @@ TEST_FILES = [
 
 @pytest.mark.parametrize("filepath, expected", TEST_FILES)
 def test_get_specformat(filepath, expected):
+    """test we can get the correct specutils format"""
     assert get_specformat(filepath) == expected
+
+
+@pytest.mark.parametrize(
+    "filepath, expected",
+    [
+        (
+            "spectro/boss/redux/v6_2_1/spectra/daily/lite/100XXX/100129/59805/spec-100129-59805-27021597855027663.fits",
+            "spec-daily-100129-59805-27021597855027663",
+        ),
+        (
+            "spectro/boss/redux/v6_2_1/spectra/epoch/lite/112XXX/112360/60287/spec-112360-60287-27021603143302004.fits",
+            "spec-epoch-112360-60287-27021603143302004",
+        ),
+        (
+            "spectro/boss/redux/v6_2_1/spectra/allepoch/lite/allepoch/allepoch_apo/59373/spec-allepoch_apo-59373-4351657527.fits",
+            "spec-allepoch_apo-59373-4351657527",
+        ),
+        (
+            "dr17/sdss/spectro/redux/26/spectra/lite/2895/spec-2895-54567-0346.fits",
+            "spec-lite-2895-54567-0346",
+        ),
+        (
+            "dr17/sdss/spectro/redux/26/spectra/full/2895/spec-2895-54567-0346.fits",
+            "spec-full-2895-54567-0346",
+        ),
+        (
+            "spectro/apogee/redux/1.5/stars/apo25m/11/11410/apStar-1.5-apo25m-2M00490869+6205128.fits",
+            "apStar-1.5-apo25m-2M00490869+6205128",
+        ),
+    ],
+    ids=["daily", "epoch", "allepoch", "lite", "full", "star"],
+)
+def test_make_label(filepath, expected):
+    """test we can make a correct label"""
+    assert make_label(filepath) == expected
+
+
+filemap = {
+    "spec-epoch-100129-60624-63050394785558224": "/Users/brian/Work/sdss/sas/ipl-4/spectro/boss/redux/v6_2_1/spectra/epoch/lite/100XXX/100129/60624/spec-100129-60624-63050394785558224.fits",
+    "mwmVisit-0.8.0-54459273": "/Users/brian/Work/sdss/sas/ipl-4/spectro/astra/spectra/visit/92/73/mwmVisit-0.8.0-54459273.fits",
+    "apVisit-1.5-apo25m-16442-60595-211": "/Users/brian/Work/sdss/sas/ipl-4/spectro/apogee/redux/1.5/visit/apo25m/100129/16442/60595/apVisit-1.5-apo25m-16442-60595-211.fits",
+    "apStar-1.5-apo25m-2M08003732+3644436": "/Users/brian/Work/sdss/sas/ipl-4/spectro/apogee/redux/1.5/stars/apo25m/39/39339/apStar-1.5-apo25m-2M08003732+3644436.fits",
+    "spec-daily-100129-59805-27021597855027663": "/Users/brian/Work/sdss/sas/ipl-4/spectro/boss/redux/v6_2_1/spectra/daily/lite/100XXX/100129/59805/spec-100129-59805-27021597855027663.fits",
+    "mwmStar-0.8.0-54459273": "/Users/brian/Work/sdss/sas/ipl-4/spectro/astra/spectra/star/92/73/mwmStar-0.8.0-54459273.fits",
+}
+
+
+def test_sort_filemap():
+    """test we can sort the data dict"""
+    new = sort_filemap(filemap)
+    assert list(new.keys()) == ["mwmStar-0.8.0-54459273",
+                                "spec-epoch-100129-60624-63050394785558224",
+                                "spec-daily-100129-59805-27021597855027663",
+                                "apStar-1.5-apo25m-2M08003732+3644436",
+                                "mwmVisit-0.8.0-54459273",
+                                "apVisit-1.5-apo25m-16442-60595-211",
+                                ]


### PR DESCRIPTION
This PR restructures the jdaviz embed code, does some cleanup in preparation for migration to jdaviz 5.0, and fixes the labeling for BHM spec files to differentiate between the different coadds. 

We are stuck at jdaviz=4.2.3 for now.  Upgrading to 4.5.2 would be nice but with version >=4.3, they switched to a new loader mechanism that breaks data loads for astra and apogee files, mwmStar/Visit and apStar/apVisit.  Once those are fixed, we can migrate directly to 5.0.  
