### PR TITLE
Fixes the query too long

### DIFF
--- a/sdss_solara/components/message.py
+++ b/sdss_solara/components/message.py
@@ -5,6 +5,8 @@ import solara
 
 # variable for storing outgoing messages to the parent
 outmsg = solara.Reactive[dict]({})
+# variable for storing incoming file updates from the parent
+new_files = solara.Reactive[list]([])
 
 
 @solara.component_vue('message.vue')
@@ -31,6 +33,9 @@ def event_handler(data: dict):
     event_type = data.get('type')
     if event_type == 'themeChange':
         check_theme(data.get('theme'))
+    elif event_type == 'updateFiles':
+        new_files.value = data.get('files') or []
+        outmsg.value = {'type': 'success', 'message': 'Files updated successfully'}
 
 
 def set_initial_theme(params: solara.Reactive[dict] = None):

--- a/sdss_solara/components/message.py
+++ b/sdss_solara/components/message.py
@@ -1,12 +1,18 @@
 
+import urllib
+
 import solara
+
+# variable for storing outgoing messages to the parent
+outmsg = solara.Reactive[dict]({})
 
 
 @solara.component_vue('message.vue')
 def Message(
-    event_update: solara.Callable[[dict], None] = None):
+    event_update: solara.Callable[[dict], None] | None = None,
+    outgoing: dict | None = None,
+    ):
     """ iframe post message component """
-    pass
 
 
 def check_theme(theme: str = None):
@@ -27,8 +33,13 @@ def event_handler(data: dict):
         check_theme(data.get('theme'))
 
 
-def set_initial_theme():
-    router = solara.use_router()
-    params = dict(i.split('=', 1) for i in router.search.split('&')) if router.search else {}
-    theme = params.get('theme')
+def set_initial_theme(params: solara.Reactive[dict] = None):
+    """set the initial theme"""
+    if params is None:
+        params = solara.use_reactive({})
+        router = solara.use_router()
+        pp = urllib.parse.parse_qs(router.search)
+        params.value = {k: v[0] if len(v) == 1 else v for k, v in pp.items()}
+
+    theme = params.value.get("theme", None)
     check_theme(theme)

--- a/sdss_solara/components/message.vue
+++ b/sdss_solara/components/message.vue
@@ -4,12 +4,14 @@
 
 <script>
 export default {
+    name: "Message",
     props: {
+        outgoing: {type: Object, default: () => ({})}
     },
     data() {
         return {
             lastMessageType: '',
-            postData: {}
+            parentOrigin: '*'
         }
     },
     mounted() {
@@ -18,15 +20,35 @@ export default {
     beforeUnmount() {
         window.removeEventListener('message', this.handleMessage)
     },
-    methods: {
-        handleMessage(event) {
-            // event handler for postMessage
-            if (event.data && event.data.type) {
-                this.lastMessageType = event.data.type
-                this.postData = event.data
-                this.update(this.postData)
+    watch: {
+        outgoing: function handler(newValue) {
+            // watch for changes to the outgoing prop
+            if (newValue && Object.keys(newValue).length > 0) {
+                this.postMessage(newValue)
             }
         }
+    },
+    methods: {
+        handleMessage(event) {
+            // handle incoming message from the parent
+            if (event.data && event.data.type) {
+                this.lastMessageType = event.data.type
+
+                // update parent origin
+                if (event.origin) {
+                    this.parentOrigin = event.origin
+                }
+
+                // call solara event handler
+                // solara maps event_update to this.update
+                // see https://solara.dev/documentation/api/utilities/component_vue#component_vue
+                this.update(event.data)
+            }
+        },
+        postMessage(message) {
+            // post message back to the parent
+            window.parent.postMessage(message, this.parentOrigin)
+        },
     }
 }
 </script>

--- a/sdss_solara/components/message.vue
+++ b/sdss_solara/components/message.vue
@@ -16,6 +16,9 @@ export default {
     },
     mounted() {
         window.addEventListener('message', this.handleMessage)
+
+        // post a ready message back to the parent
+        window.parent.postMessage('ready', this.parentOrigin)
     },
     beforeUnmount() {
         window.removeEventListener('message', this.handleMessage)

--- a/sdss_solara/pages/jdaviz_embed.py
+++ b/sdss_solara/pages/jdaviz_embed.py
@@ -14,7 +14,13 @@ from specutils import Spectrum, SpectrumList
 from ipypopout import PopoutButton
 
 from sdss_solara.components.common import create_shared_widgets, css
-from sdss_solara.components.message import Message, event_handler, outmsg, set_initial_theme
+from sdss_solara.components.message import (
+    Message,
+    event_handler,
+    new_files,
+    outmsg,
+    set_initial_theme,
+)
 
 
 def local_check():
@@ -129,6 +135,7 @@ def sort_filemap(data: dict) -> dict:
 # reactive variables
 spec = solara.reactive(None)
 selected = solara.reactive([])
+all_files = solara.reactive([])
 filemap = solara.reactive({})
 params = solara.reactive({})
 
@@ -168,11 +175,16 @@ def make_label(filepath):
         return stem
 
 
+def sync_file_state():
+    """Keep all_files and selected aligned with the current filemap."""
+    all_files.value = list(filemap.value.keys())
+    current_selected = [i for i in selected.value if i in filemap.value]
+    selected.value = current_selected or ([all_files.value[0]] if all_files.value else [])
+
+
 @solara.component
 def DataSelect():
     """component for a dropdown select menu"""
-    all_files = solara.use_reactive([])
-
     sdssid = params.value.get("sdssid", "")
     release = params.value.get("release", "IPL3")
     qp_files = params.value.get("files", "")
@@ -194,27 +206,24 @@ def DataSelect():
 
         vals = {make_label(i): i for i in resp.json()["files"].values()}
         filemap.value = sort_filemap(vals) if not set(vals) == {""} else {}
-        return list(filemap.value.keys())
+        sync_file_state()
+        return list(all_files.value)
 
     def get_files():
         """get the spectral data files"""
         if filemap.value:
-            all_files.value = list(filemap.value.keys())
-            selected.value = [all_files.value[0]] if all_files.value else []
+            sync_file_state()
             return
 
         if sdssid and not qp_files:
             res = make_request()
             print("finished req", res)
-            all_files.value = res or []
-            selected.value = [all_files.value[0]] if all_files.value else []
         elif sdssid and qp_files:
             print("getting files", sdssid, qp_files)
             filemap.value = sort_filemap(
                 {make_label(i): i for i in qp_files.split(",") if check_file_exists(i, release)}
             )
-            all_files.value = list(filemap.value.keys())
-            selected.value = [all_files.value[0]] if all_files.value else []
+            sync_file_state()
 
     if not all_files.value:
         get_files()
@@ -222,7 +231,7 @@ def DataSelect():
     solara.SelectMultiple("Select Data Files", selected, all_files.value, dense=True)
 
 
-def load_data(app: Application, filename: str):
+def load_data(app: Application, filename: str, resize: bool = False):
     """Load the data into Jdaviz"""
     label = make_label(filename)
     lal = (
@@ -233,12 +242,20 @@ def load_data(app: Application, filename: str):
         else False
     )
 
+    if not os.path.exists(filename):
+        print('File does not exist:', filename)
+        return
+
     # 4.2.3
     app.load_data(
         filename, format=get_specformat(filename), load_as_list=lal, data_label=label
     )
     # obj = get_spectrum(label)
     # app.load_data(obj, format=get_specformat(filename), load_as_list=lal, data_label=label, sources='*')
+
+    # resize the plot axes
+    if resize:
+        smart_resize(app)
 
 
 @solara.component
@@ -300,10 +317,39 @@ def load_app():
     error = None
     if filemap.value:
         label = list(filemap.value.keys())[0]
-        load_data(spec.value, filemap.value[label])
-        smart_resize(spec.value)
+        load_data(spec.value, filemap.value[label], resize=True)
 
     return app, error
+
+
+def consume_new_files():
+    """Consume new_files updates and clear the queue."""
+    if not new_files.value:
+        return
+
+    files = new_files.value
+
+    # make a new filemap with the new files
+    release = params.value.get("release", "IPL3")
+    incoming = {make_label(i): i for i in files if i and check_file_exists(i, release)}
+    if not incoming:
+        return
+
+    # check if the filemap was previously empty
+    empty_prior = not filemap.value
+
+    # merge the two dictionaries
+    merged = dict(filemap.value)
+    merged.update(incoming)
+    filemap.value = sort_filemap(merged)
+    sync_file_state()
+
+    # load the first data file if the viewer was empty before
+    if empty_prior and selected.value:
+        load_data(spec.value, filemap.value[selected.value[0]], resize=True)
+
+    # reset the new files
+    new_files.value = []
 
 
 @solara.component
@@ -353,7 +399,10 @@ def Page():
 
         Jdaviz()
 
+    # refresh available files when parent sends updateFiles postMessage
+    solara.use_effect(consume_new_files, [new_files.value])
+
     # with solara we have to use use_effect + get_widget to get the widget id
-    solara.use_effect(lambda: target_model_id.set(solara.get_widget(control)._model_id))
+    solara.use_effect(lambda: target_model_id.set(solara.get_widget(control)._model_id), [])
 
 Page()

--- a/sdss_solara/pages/jdaviz_embed.py
+++ b/sdss_solara/pages/jdaviz_embed.py
@@ -211,7 +211,7 @@ def DataSelect():
         elif sdssid and qp_files:
             print("getting files", sdssid, qp_files)
             filemap.value = sort_filemap(
-                {make_label(i): i for i in qp_files.split(",")}
+                {make_label(i): i for i in qp_files.split(",") if check_file_exists(i, release)}
             )
             all_files.value = list(filemap.value.keys())
             selected.value = [all_files.value[0]] if all_files.value else []
@@ -255,6 +255,12 @@ def DataLoader():
                 load_data(spec.value, filemap.value[f])
 
     solara.Button("Load Data", color="primary", on_click=load)
+
+
+def check_file_exists(filepath: str, release: str) -> bool:
+    """ Add a file check existence """
+    access = Access(release=release)
+    return access.exists('', full=filepath)
 
 
 def get_urls(files: list, release: str):

--- a/sdss_solara/pages/jdaviz_embed.py
+++ b/sdss_solara/pages/jdaviz_embed.py
@@ -14,7 +14,7 @@ from specutils import Spectrum, SpectrumList
 from ipypopout import PopoutButton
 
 from sdss_solara.components.common import create_shared_widgets, css
-from sdss_solara.components.message import Message, event_handler, set_initial_theme
+from sdss_solara.components.message import Message, event_handler, outmsg, set_initial_theme
 
 
 def local_check():
@@ -329,12 +329,12 @@ def Page():
     target_model_id = solara.use_reactive("")
 
     # set initial theme
-    set_initial_theme()
+    set_initial_theme(params)
 
     solara.Style(css)
     with solara.Column() as control:
         solara.Title("Spectral Display")
-        Message(event_update=event_handler)
+        Message(event_update=event_handler, outgoing=outmsg.value)
 
         with solara.Columns([1, 0, 0], style="margin: 0 5px"):
             DataSelect()


### PR DESCRIPTION
Closes #14.  This PR updates the logic to accept an iframe post message with new files to add to the solara DataSelect component.  Only one file is sent now as a query parameter, which should resolve the url too long error from nginx.  The rest of the files are sent after the solara server is up and running.  A "ready" postMessage is sent back to the parent when the message component is mounted.  